### PR TITLE
Pass complete user object to @start()

### DIFF
--- a/build/logger.js
+++ b/build/logger.js
@@ -22,11 +22,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var EventLog, resin;
+var EventLog, resin, token;
 
 EventLog = require('resin-event-log');
 
 resin = require('resin-sdk');
+
+token = require('resin-token');
 
 
 /**
@@ -47,12 +49,12 @@ resin = require('resin-sdk');
  */
 
 exports.getInstance = function() {
-  return resin.models.config.getMixpanelToken().then(function(token) {
-    return EventLog(token, 'CLI', {
+  return resin.models.config.getMixpanelToken().then(function(mixpanelToken) {
+    return EventLog(mixpanelToken, 'CLI', {
       beforeCreate: function(type, jsonData, applicationId, deviceId, callback) {
-        return resin.auth.getUserId().then((function(_this) {
-          return function(userId) {
-            return _this.start(userId, callback);
+        return token.getData().then((function(_this) {
+          return function(user) {
+            return _this.start(user, callback);
           };
         })(this))["catch"](callback);
       },

--- a/lib/logger.coffee
+++ b/lib/logger.coffee
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 EventLog = require('resin-event-log')
 resin = require('resin-sdk')
+token = require('resin-token')
 
 ###*
 # @summary Get event logger instance
@@ -42,12 +43,12 @@ resin = require('resin-sdk')
 # 	instance.user.login()
 ###
 exports.getInstance = ->
-	resin.models.config.getMixpanelToken().then (token) ->
-		return EventLog token, 'CLI',
+	resin.models.config.getMixpanelToken().then (mixpanelToken) ->
+		return EventLog mixpanelToken, 'CLI',
 
 			beforeCreate: (type, jsonData, applicationId, deviceId, callback) ->
-				resin.auth.getUserId().then (userId) =>
-					@start(userId, callback)
+				token.getData().then (user) =>
+					@start(user, callback)
 				.catch(callback)
 
 			afterCreate: (type) ->

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bluebird": "^2.9.34",
     "lodash": "^3.10.1",
     "resin-event-log": "0.0.5",
-    "resin-sdk": "^2.7.0"
+    "resin-sdk": "^2.7.0",
+    "resin-token": "^2.4.1"
   }
 }


### PR DESCRIPTION
This is required for `resin-events-log` to work correctly. User id is
not enough anymore.
