### PR TITLE
Upgrade resin-event-log to v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "lodash": "^3.10.1",
-    "resin-event-log": "0.0.5",
+    "resin-event-log": "0.0.6",
     "resin-sdk": "^2.7.0",
     "resin-token": "^2.4.1"
   }


### PR DESCRIPTION
Contains fixes to a bug that prevented the module to work correctly on
NodeJS.
