### PR TITLE
Memoize logger instance

### DIFF
--- a/build/logger.js
+++ b/build/logger.js
@@ -22,13 +22,15 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var EventLog, resin, token;
+var EventLog, resin, token, _;
 
 EventLog = require('resin-event-log');
 
 resin = require('resin-sdk');
 
 token = require('resin-token');
+
+_ = require('lodash');
 
 
 /**
@@ -48,7 +50,7 @@ token = require('resin-token');
  * 	instance.user.login()
  */
 
-exports.getInstance = function() {
+exports.getInstance = _.memoize(function() {
   return resin.models.config.getMixpanelToken().then(function(mixpanelToken) {
     return EventLog(mixpanelToken, 'CLI', {
       beforeCreate: function(type, jsonData, applicationId, deviceId, callback) {
@@ -65,4 +67,4 @@ exports.getInstance = function() {
       }
     });
   });
-};
+});

--- a/lib/logger.coffee
+++ b/lib/logger.coffee
@@ -25,6 +25,7 @@ THE SOFTWARE.
 EventLog = require('resin-event-log')
 resin = require('resin-sdk')
 token = require('resin-token')
+_ = require('lodash')
 
 ###*
 # @summary Get event logger instance
@@ -42,7 +43,7 @@ token = require('resin-token')
 # logger.getInstance().then (instance) ->
 # 	instance.user.login()
 ###
-exports.getInstance = ->
+exports.getInstance = _.memoize ->
 	resin.models.config.getMixpanelToken().then (mixpanelToken) ->
 		return EventLog mixpanelToken, 'CLI',
 


### PR DESCRIPTION
Prevent attempting to get the mixpanel token each time we want to send
an event.
