### PR TITLE
Upgrade `resin-event-log` to `v0.1.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "lodash": "^3.10.1",
-    "resin-event-log": "0.0.6",
+    "resin-event-log": "0.1.1",
     "resin-sdk": "^4.0.0",
     "resin-token": "^2.4.1"
   }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti jviottidc@gmail.com
