### PR TITLE
Deprecate this package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+---
+
+# resin-cli-events is deprecated, and no longer in use. You might be looking for [resin-analytics](https://github.com/resin-io-modules/resin-analytics).
+
+---
+
 resin-cli-events
 ----------------
 


### PR DESCRIPTION
This is no longer in use in the CLI and unmaintained, so mark it as such.

I considered deleting it entirely, but it might be useful later, and pulling published code from npm is hard work, so it'll always be referred to from there.

Once this is merged I'll `npm deprecate` the whole package, so installing that comes back with the same message too.